### PR TITLE
chore: .idea uitsluiten via .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+.idea/


### PR DESCRIPTION
Wat is er gedaan?
In deze PR heb ik het .gitignore-bestand bijgewerkt.

Waarom?
IDE-specifieke bestanden (zoals .idea/) mogen niet in de repository staan, omdat ze persoonlijk zijn en bij elke developer verschillen.

Resultaat:

.idea/ wordt nu correct genegeerd

De repository blijft schoon en consistent voor het hele team

Graag even reviewen 👍