### PR TITLE
Ads: ownership enforcement and authorization (401/403)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -35,4 +35,3 @@ app.include_router(register_router)
 app.include_router(login_router)
 app.include_router(users_router)
 app.include_router(logout_router)
-

--- a/app/main.py
+++ b/app/main.py
@@ -1,23 +1,14 @@
 import app.core.config
 from fastapi import FastAPI
+from app.db.database import Base, engine
 
 from app.routers.ads import router as ads_crud_router
 from app.routers.ad_search import router as ad_search_router
-
 from app.routers.register import router as register_router
 from app.routers.login import router as login_router
 from app.routers.users import router as users_router
 from app.routers.logout import router as logout_router
 from app.routers.comments import router as comments_router
-
-from app.routers.logout import router as logout_router
-from app.routers.users import router as users_router
-from app.routers.ad_search import router as ads_router
-
-
-
-from app.db.database import Base, engine
-
 
 app = FastAPI(
     title="Marktplaats API",
@@ -25,22 +16,19 @@ app = FastAPI(
     version="1.0.0"
 )
 
-# create tables
 Base.metadata.create_all(bind=engine)
 
 
 @app.get("/")
 def root():
-    return {"message": "MarktPlaats API is running"}
+    return {"message": "Marktplaats API is running"}
 
 
 # Register routers
-app.include_router(ads_crud_router)  # CRUD/ads
-app.include_router(ad_search_router)  # /ads/search
 app.include_router(register_router)
 app.include_router(login_router)
 app.include_router(users_router)
 app.include_router(logout_router)
+app.include_router(ads_crud_router)  # CRUD/ads
+app.include_router(ad_search_router)  # /ads/search
 app.include_router(comments_router)
-
-

--- a/app/models/ads.py
+++ b/app/models/ads.py
@@ -1,5 +1,7 @@
 from app.db.database import Base
-from sqlalchemy import Column, Integer, String, Float
+from sqlalchemy import (Column, Integer, String, Float,
+                        ForeignKey, DateTime, func, JSON)
+from sqlalchemy.orm import relationship
 
 
 class Ad(Base):
@@ -11,4 +13,17 @@ class Ad(Base):
     title = Column(String(255), nullable=False)
     description = Column(String(1000), nullable=True)
     price = Column(Float, nullable=False)
-    category = Column(String(100), nullable=False)
+    category = Column(JSON, nullable=False)
+
+    owner_id = Column(Integer, ForeignKey("users.id"),
+                      nullable=False, index=True)
+    owner = relationship("User")
+
+    created_at = Column(DateTime(timezone=True),
+                        server_default=func.now(),
+                        nullable=False)
+
+    updated_at = Column(DateTime(timezone=True),
+                        server_default=func.now(),
+                        onupdate=func.now(),
+                        nullable=False)

--- a/app/routers/ads.py
+++ b/app/routers/ads.py
@@ -1,94 +1,115 @@
-from fastapi import (APIRouter, Depends, HTTPException, status)
+from fastapi import APIRouter, Depends, status
 from sqlalchemy.orm import Session
 from typing import List
+
 from app.db.database import get_db
-from app.models.ads import Ad
 from app.schemas.ads import AdOut, AdCreate, AdUpdate
+from app.core.deps import get_current_user
+from app.services.ads_service import AdsService
 
 router = APIRouter(prefix="/ads", tags=["ads"])
 
 
-def get_ad_or_404(db: Session, ad_id: int) -> Ad:
-    # ad = db.get(Ad, ad_id)  # query/filter
-    ad = db.query(Ad).filter(Ad.id == ad_id).first()
-
-    if not ad:
-        raise HTTPException(status_code=404, detail=f"Ad {ad_id} not found")
-    return ad
+def get_ads_service(db: Session = Depends(get_db)):
+    return AdsService(db)
 
 
 # 1- create ad
-@router.post("/", response_model=AdOut,
-             status_code=status.HTTP_201_CREATED, summary="Create ad", )
-def create_ad(payload: AdCreate, db: Session = Depends(get_db)):
-    # 1) Convert Pydantic schema -> dict
-    data = payload.model_dump()
+@router.post("/", response_model=AdOut, status_code=status.HTTP_201_CREATED,
+             summary="Create a new advertisement",
+             description="""
+             Creates a new advertisement for the currently authenticated user.
 
-    # 2) Create ORM object (represents a row in the table)
-    ad = Ad(**data)
+             Requirements:
+             - User must be logged in.
+             - The advertisement will automatically be linked to the logged-in user.
 
-    # 3) Add + commit (save to DB)
-    db.add(ad)
-    db.commit()
+             Validation rules:
+             - title: required
+             - price: must be a positive number
+             - category: must be a list of strings
 
-    # 4) Refresh to load generated fields (like id) from DB
-    db.refresh(ad)
-
-    # 5) Return ORM object (Pydantic will serialize it using AdOut)
-    return ad
+             Notes:
+             - The owner of the ad is determined from the JWT token.
+             """)
+def create_ad_endpoint(payload: AdCreate, current_user=Depends(get_current_user),
+                       service: AdsService = Depends(get_ads_service)):
+    return service.create_ad(payload, current_user.id)
 
 
 # 2- get id ad
 @router.get("/{ad_id:int}", response_model=AdOut,
-            summary="Get ad by id", description="Get an advertisement by id.")
-def get_ad_by_id(ad_id: int, db: Session = Depends(get_db)):
-    ad = get_ad_or_404(db, ad_id)
-    return ad
+            summary="Get advertisement by ID",
+            description="""
+            Returns a single advertisement by its ID.
+
+            Notes:
+            - The ID must be an integer.
+            - This endpoint is public and does not require authentication.
+
+            Errors:
+            - 404 if the advertisement does not exist.
+            """)
+def get_ad_by_id(ad_id: int,
+                 service: AdsService = Depends(get_ads_service)):
+    return service.get_ad_or_404(ad_id)
 
 
 # 3- update ad
 @router.patch("/{ad_id:int}", response_model=AdOut,
-              summary="Update ad", description="Update an advertisement.")
-def update_ad(ad_id: int,
-              payload: AdUpdate, db: Session = Depends(get_db)):
-    # 1) Get the current ad from DB
-    ad = get_ad_or_404(db, ad_id)
+              summary="Update an existing advertisement",
+              description="""
+              Updates an existing advertisement.
 
-    # 2) Convert payload to dict, but only include fields the client actually sent
-    data = payload.model_dump(exclude_unset=True)
-    if not data:
-        raise HTTPException(status_code=400, detail="No fields provided to update")
+              Requirements:
+              - User must be logged in.
+              - Only the owner of the advertisement can update it.
 
-    # 3) Apply only provided fields to the ORM object
-    for key, value in data.items():
-        setattr(ad, key, value)
+              Validation rules:
+              - Only provided fields will be updated.
+              - price must be a positive number if provided.
+              - category must be a list of strings if provided.
 
-    # 4) Save changes
-    db.commit()
-    db.refresh(ad)
-
-    # 5) Return updated ad
-    return ad
+              Errors:
+              - 401 if user is not authenticated.
+              - 403 if user is not the owner of the advertisement.
+              - 404 if the advertisement does not exist.
+              """)
+def update_ad(ad_id: int, payload: AdUpdate, current_user=Depends(get_current_user),
+              service: AdsService = Depends(get_ads_service)):
+    return service.update_ad(ad_id, payload, current_user.id)
 
 
 # 4- delete ad
-@router.delete("/{ad_id:int}", status_code=status.HTTP_204_NO_CONTENT, summary="Delete ad",
-               description="Delete an advertisement.")
-def delete_ad(ad_id: int, db: Session = Depends(get_db)):
-    # 1) Get ad from DB
-    ad = get_ad_or_404(db, ad_id)
+@router.delete("/{ad_id:int}", status_code=status.HTTP_204_NO_CONTENT,
+               summary="Delete an advertisement",
+               description="""
+               Deletes an advertisement by its ID.
 
-    # 2) Delete ad
-    db.delete(ad)
-    db.commit()
+               Requirements:
+               - User must be logged in.
+               - Only the owner of the advertisement can delete it.
 
-    # 3) No content returned
-    return
+               Errors:
+               - 401 if user is not authenticated.
+               - 403 if user is not the owner of the advertisement.
+               - 404 if the advertisement does not exist.
+               """)
+def delete_ad_endpoint(ad_id: int, current_user=Depends(get_current_user),
+                       service: AdsService = Depends(get_ads_service), ):
+    service.delete_ad(ad_id, current_user.id)
+    return None
 
 
 # 5- get all ads
 @router.get("/", response_model=List[AdOut],
-            summary="List ads", description="Return a list of ads.")
-def get_all_ads(db: Session = Depends(get_db)):
-    ads = db.query(Ad).all()
-    return ads
+            summary="List all advertisements",
+            description="""
+            Returns a list of all advertisements.
+
+            Notes:
+            - This endpoint is public.
+            - Each advertisement includes the owner's username and the timestamp when the advertisement was created.
+            """)
+def get_all_ads(service: AdsService = Depends(get_ads_service), ):
+    return service.list_ads()

--- a/app/schemas/ads.py
+++ b/app/schemas/ads.py
@@ -1,5 +1,12 @@
-from pydantic import BaseModel, ConfigDict, PositiveFloat
-from typing import Optional
+from pydantic import (BaseModel
+, ConfigDict, PositiveFloat)
+from typing import Optional, List
+from datetime import datetime
+
+
+class OwnerOut(BaseModel):
+    username: str
+    model_config = ConfigDict(from_attributes=True)
 
 
 class AdBase(BaseModel):
@@ -7,7 +14,7 @@ class AdBase(BaseModel):
     title: str
     description: Optional[str] = None
     price: PositiveFloat
-    category: str
+    category: List[str]
 
 
 class AdCreate(AdBase):
@@ -22,12 +29,16 @@ class AdUpdate(BaseModel):
        """
     title: Optional[str] = None
     description: Optional[str] = None
-    price: Optional[float] = None
-    category: Optional[str] = None
+    price: Optional[PositiveFloat] = None
+    category: Optional[List[str]] = None
 
 
 class AdOut(AdBase):
     """Schema returned to the client."""
     id: int
+    created_at: datetime
+    owner: OwnerOut
+
+
     # Allows returning SQLAlchemy objects directly (ORM mode in Pydantic v2)
     model_config = ConfigDict(from_attributes=True)

--- a/app/services/ads_service.py
+++ b/app/services/ads_service.py
@@ -1,0 +1,56 @@
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+from app.models.ads import Ad
+from typing import Literal
+
+
+class AdsService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def _require_owner(self, ad: Ad, current_user_id: int, action: Literal["update", "delete"]):
+        if ad.owner_id != current_user_id:
+            message = {
+                "update": "You do not have permission to update this advertisement.",
+                "delete": "You do not have permission to delete this advertisement.", }
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN,
+                                detail=message[action])
+
+    def get_ad_or_404(self, ad_id: int) -> Ad:
+        ad = self.db.query(Ad).filter(Ad.id == ad_id).first()
+        if not ad:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                                detail=f"Ad {ad_id} not found")
+        return ad
+
+    def create_ad(self, payload, current_user_id: int):
+        data = payload.model_dump()
+        data["owner_id"] = current_user_id  # de eigenaar van de token
+
+        ad = Ad(**data)
+        self.db.add(ad)
+        self.db.commit()
+        self.db.refresh(ad)
+        return ad
+
+    def update_ad(self, ad_id: int, payload, current_user_id: int):
+        ad = self.get_ad_or_404(ad_id)
+        self._require_owner(ad, current_user_id, action="update")
+
+        updates = payload.model_dump(exclude_unset=True)
+        for key, value in updates.items():
+            setattr(ad, key, value)
+
+        self.db.commit()
+        self.db.refresh(ad)
+        return ad
+
+    def delete_ad(self, ad_id: int, current_user_id: int):
+        ad = self.get_ad_or_404(ad_id)
+        self._require_owner(ad, current_user_id, action="delete")
+
+        self.db.delete(ad)
+        self.db.commit()
+
+    def list_ads(self):
+        return self.db.query(Ad).all()


### PR DESCRIPTION
This PR implements ownership and authorization checks for advertisements.

- Secured PATCH /ads/{id} and DELETE /ads/{id}
- 401 Unauthorized for unauthenticated users
- 403 Forbidden for non-owners (owner_id vs current_user.id)
- Business logic moved to service layer (no logic in main.py)
- Clear and consistent error messages
- Improved Swagger documentation

Acceptance Criteria covered:
- Owner-only modification and deletion
- Correct HTTP status codes
- Secure JWT-based ownership validation
