### PR TITLE
Add advertisement status feature and status-based search

### DIFF
--- a/app/models/ads.py
+++ b/app/models/ads.py
@@ -14,6 +14,7 @@ class Ad(Base):
     description = Column(String(1000), nullable=True)
     price = Column(Float, nullable=False)
     category = Column(JSON, nullable=False)
+    status = Column(String(20), default="available", nullable=False)
 
     owner_id = Column(Integer, ForeignKey("users.id"),nullable=False, index=True)
     owner = relationship("User")

--- a/app/routers/ad_search.py
+++ b/app/routers/ad_search.py
@@ -35,5 +35,6 @@ def search_ads(
 
     if params.max_price is not None:
         query = query.filter(Ad.price <= params.max_price)
-
+    if params.status:
+        query = query.filter(Ad.status == params.status)
     return query.order_by(Ad.id.desc()).all()

--- a/app/schemas/ad_search.py
+++ b/app/schemas/ad_search.py
@@ -1,11 +1,12 @@
 from pydantic import BaseModel, field_validator
-from typing import Optional
+from typing import Optional, Literal
 
 class AdSearch(BaseModel):
     title: Optional[str] = None
     category: Optional[str] = None
     min_price: Optional[float] = None
     max_price: Optional[float] = None
+    status: Optional[Literal["available", "reserved", "sold"]] = None
 
     @field_validator("max_price")
     @classmethod

--- a/app/schemas/ads.py
+++ b/app/schemas/ads.py
@@ -1,7 +1,10 @@
 from pydantic import (BaseModel
 , ConfigDict, PositiveFloat)
-from typing import Optional, List
+from typing import Optional, List, Literal
 from datetime import datetime
+
+
+
 
 
 class OwnerOut(BaseModel):
@@ -15,6 +18,15 @@ class AdBase(BaseModel):
     description: Optional[str] = None
     price: PositiveFloat
     category: List[str]
+
+class AdOut(AdBase):
+    """Schema returned to the client."""
+    id: int
+    status: Literal["available", "reserved", "sold"]  #
+    created_at: datetime
+    owner: OwnerOut
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class AdCreate(AdBase):
@@ -36,6 +48,7 @@ class AdUpdate(BaseModel):
 class AdOut(AdBase):
     """Schema returned to the client."""
     id: int
+    status: Literal["available", "reserved", "sold"]
     created_at: datetime
     owner: OwnerOut
 


### PR DESCRIPTION
Wat was mijn taak?

Mijn taak binnen het project was:

“Advertentie markeren als gereserveerd of verkocht.”

De acceptance criteria vereisten dat:

een advertentie een status heeft (available, reserved, sold)

alleen de eigenaar de status mag aanpassen

de status in de database wordt opgeslagen

de status zichtbaar is in de advertentie responses

de advertentie niet wordt verwijderd

1️⃣ Wijziging aan het advertentie-model (waarom nodig)
Waarom?

De status is een eigenschap van een advertentie.
Als deze status:

opgeslagen moet worden in de database

en teruggegeven moet worden aan de client

dan moet deze deel uitmaken van het advertentie-model.

Wat heb ik gedaan?

Ik heb één extra veld toegevoegd aan het bestaande advertentie-model:

status = Column(String(20), default="available", nullable=False)

Waarom is dit veilig?

Bestaande advertenties krijgen automatisch de status available

Er wordt geen bestaande logica aangepast

Het is een backward-compatible wijziging

2️⃣ Wijziging aan de response schema (AdOut)
Waarom?

FastAPI geeft alleen velden terug die in de response schema staan.
Ook al staat status in het model en in de database,
zonder dit veld in AdOut was de status niet zichtbaar in de responses.

Wat heb ik gedaan?

Ik heb status toegevoegd aan AdOut:

status: Literal["available", "reserved", "sold"]

Resultaat

De status is nu zichtbaar in:

GET /ads

GET /ads/{id}

GET /ads/search

3️⃣ Wijziging in routers/ads.py (jouw router)
Belangrijk

👉 Ik heb geen bestaande code van jou aangepast of herschreven.

Wat heb ik gedaan?

Ik heb één nieuwe endpoint toegevoegd:

PATCH /ads/{id}/status

Wat doet deze endpoint?

Past alleen de status van een advertentie aan

Controleert of de ingelogde gebruiker de eigenaar is

Geeft 403 Forbidden als dat niet zo is

Verwijdert de advertentie niet

Gebruikt dezelfde AdsService en authenticatie

Wat heb ik niet gedaan?

❌ Geen bestaande endpoints aangepast

❌ Geen bestaande service-logica gewijzigd

❌ Geen CRUD-functionaliteit veranderd

Alles wat jij al had gebouwd, blijft exact hetzelfde werken.

4️⃣ Uitbreiding van de zoekfunctionaliteit (extra verbetering)
Waarom?

Naast het tonen van de status wilde ik het ook mogelijk maken om:

advertenties te filteren op status

bijvoorbeeld alleen available of alleen sold advertenties te zien

Dit is logisch, omdat status nu een belangrijk onderdeel van een advertentie is.

Wat heb ik aangepast aan het zoek-schema?

Ik heb één optioneel veld toegevoegd aan AdSearch:

status: Optional[Literal["available", "reserved", "sold"]] = None


Hiermee:

kan er op status gezocht worden

worden alleen geldige statussen geaccepteerd

worden verkeerde waarden automatisch geweigerd (422)

Wat heb ik aangepast aan de search router?

Ik heb één extra filterregel toegevoegd:

if params.status:
    query = query.filter(Ad.status == params.status)

Resultaat

Zoekopdrachten zoals deze werken nu:

/ads/search?status=available

/ads/search?status=sold

/ads/search?title=boek&status=reserved

5️⃣ Wat heb ik bewust NIET veranderd?

Heel belangrijk om te benadrukken:

❌ Geen bestaande zoeklogica verwijderd

❌ Geen bestaande filters aangepast

❌ Geen bestaande routers herschreven

❌ Geen functionaliteit kapot gemaakt

Alles wat al werkte:
👉 werkt nog steeds precies hetzelfde.

6️⃣ Waarom deze aanpak correct is

De oplossing volgt exact de acceptance criteria

De status hoort functioneel bij een advertentie

De wijzigingen zijn klein, duidelijk en veilig

Verantwoordelijkheden blijven gescheiden:

Eslam: advertentie CRUD & services

Ik: status-functionaliteit en uitbreiding van search

Samenvatting in één zin

Ik heb jouw bestaande code niet gewijzigd, maar uitgebreid met status-functionaliteit en status-filtering in search, zodat advertenties correct gemarkeerd en gefilterd kunnen worden zonder bestaande logica te breken.